### PR TITLE
Allow disabling of the rotate buttons via OpenCropperOptions and rotate control

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ If outputting a JPEG image, the compression quality for the output image.
 
 ### `rotationEnabled?: boolean`
 
-Whether or not to allow the user to rotate the image. Default is `true`.
+Whether or not to allow the user to rotate the image in 90 degree segments. Default is `true`.
+
+### `rotationControlEnabled?: boolean`
+
+Whether or not to show the rotation control view. Default is `true` (iOS ONLY).
 
 ## `OpenCropperResult`
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ pod install
 
 For basic examples, see `example/App.tsx`.
 
-## `openCropper(options: OpenCropperOptions) => Promise<OpenCropperResult>`
+## `openCropperAsync(options: OpenCropperOptions) => Promise<OpenCropperResult>`
 
-`openCropper` will return the path to the cropped image, or will throw an error if something goes wrong.
+`openCropperAsync` will return the path to the cropped image, or will throw an error if something goes wrong.
 
 ## `OpenCropperOptions`
 
@@ -46,7 +46,11 @@ The format of the output image. Default is `png`.
 
 ### `compressImageQuality?: number`
 
-If outputing a JPEG image, the compression quality for the output image.
+If outputting a JPEG image, the compression quality for the output image.
+
+### `rotationEnabled?: boolean`
+
+Whether or not to allow the user to rotate the image. Default is `true`.
 
 ## `OpenCropperResult`
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,4 +44,5 @@ android {
 dependencies {
   implementation 'androidx.appcompat:appcompat:1.7.0'
   implementation 'com.vanniktech:android-image-cropper:4.6.0'
+  implementation 'com.google.android.material:material:1.9.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,5 +44,4 @@ android {
 dependencies {
   implementation 'androidx.appcompat:appcompat:1.7.0'
   implementation 'com.vanniktech:android-image-cropper:4.6.0'
-  implementation 'com.google.android.material:material:1.9.0'
 }

--- a/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperActivity.kt
+++ b/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperActivity.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import android.util.Log
 import android.util.TypedValue
 import android.view.Gravity
+import android.view.View
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.view.WindowManager
@@ -17,6 +18,7 @@ import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatButton
+import androidx.appcompat.widget.AppCompatImageButton
 import androidx.core.graphics.toColorInt
 import androidx.core.net.toUri
 import androidx.core.view.ViewCompat
@@ -26,12 +28,12 @@ import com.canhub.cropper.CropImageView
 import java.io.File
 
 private fun Context.dpToPx(dp: Int): Int =
-  TypedValue
-    .applyDimension(
-      TypedValue.COMPLEX_UNIT_DIP,
-      dp.toFloat(),
-      resources.displayMetrics,
-    ).toInt()
+        TypedValue.applyDimension(
+                        TypedValue.COMPLEX_UNIT_DIP,
+                        dp.toFloat(),
+                        resources.displayMetrics,
+                )
+                .toInt()
 
 // https://gist.github.com/codeswimmer/858833?permalink_comment_id=2347183#gistcomment-2347183
 fun Bitmap.rotate(degrees: Float): Bitmap {
@@ -51,50 +53,50 @@ class CropperActivity : AppCompatActivity() {
     WindowCompat.setDecorFitsSystemWindows(window, false)
 
     val options =
-      intent.extras?.let {
-        OpenCropperOptions.fromBundle(it)
-      } ?: run {
-        setResult(CropperError.Arguments.getResultCode(), null)
-        finish()
-        return
-      }
+            intent.extras?.let { OpenCropperOptions.fromBundle(it) }
+                    ?: run {
+                      setResult(CropperError.Arguments.getResultCode(), null)
+                      finish()
+                      return
+                    }
     this.options = options
 
     val cropView =
-      CropImageView(this).apply {
-        options.imageUri?.let { setImageUriAsync(it.toUri()) } ?: run {
-          setResult(CropperError.OpenImage.getResultCode(), null)
-          finish()
-          return
-        }
+            CropImageView(this).apply {
+              options.imageUri?.let { setImageUriAsync(it.toUri()) }
+                      ?: run {
+                        setResult(CropperError.OpenImage.getResultCode(), null)
+                        finish()
+                        return
+                      }
 
-        options.shape?.let {
-          cropShape =
-            when (it) {
-              "rectangle" -> CropImageView.CropShape.RECTANGLE
-              "circle" -> CropImageView.CropShape.OVAL
-              else -> {
-                setResult(CropperError.Arguments.getResultCode(), null)
-                finish()
-                return
+              options.shape?.let {
+                cropShape =
+                        when (it) {
+                          "rectangle" -> CropImageView.CropShape.RECTANGLE
+                          "circle" -> CropImageView.CropShape.OVAL
+                          else -> {
+                            setResult(CropperError.Arguments.getResultCode(), null)
+                            finish()
+                            return
+                          }
+                        }
+              }
+
+              if (options.shape == "circle") {
+                setFixedAspectRatio(true)
+                setAspectRatio(1, 1)
+              } else {
+                options.aspectRatio?.let {
+                  if (it <= 0) {
+                    setFixedAspectRatio(false)
+                  } else {
+                    setFixedAspectRatio(true)
+                    setAspectRatio((it * 100).toInt(), 100)
+                  }
+                }
               }
             }
-        }
-
-        if (options.shape == "circle") {
-          setFixedAspectRatio(true)
-          setAspectRatio(1, 1)
-        } else {
-          options.aspectRatio?.let {
-            if (it <= 0) {
-              setFixedAspectRatio(false)
-            } else {
-              setFixedAspectRatio(true)
-              setAspectRatio((it * 100).toInt(), 100)
-            }
-          }
-        }
-      }
 
     this.cropView = cropView
 
@@ -104,88 +106,138 @@ class CropperActivity : AppCompatActivity() {
       insets
     }
 
-    val root =
-      FrameLayout(this).apply {
-        setBackgroundColor(Color.BLACK)
-      }
+    val root = FrameLayout(this).apply { setBackgroundColor(Color.BLACK) }
 
     root.addView(
-      cropView,
-      FrameLayout.LayoutParams(
-        MATCH_PARENT,
-        MATCH_PARENT,
-      ),
+            cropView,
+            FrameLayout.LayoutParams(
+                    MATCH_PARENT,
+                    MATCH_PARENT,
+            ),
     )
 
     val bar =
-      LinearLayout(this).apply {
-        orientation = LinearLayout.HORIZONTAL
-        setBackgroundColor("#66000000".toColorInt())
-        val dp16 = dpToPx(16)
-        setPadding(dp16, dp16, dp16, dp16)
-        gravity = Gravity.CENTER
-      }
-
-    fun LinearLayout.LayoutParams.withMargin() =
-      apply {
-        width = 0
-        weight = 1f
-        setMargins(dpToPx(4), 0, dpToPx(4), 0)
-      }
+            LinearLayout(this).apply {
+              orientation = LinearLayout.HORIZONTAL
+              setBackgroundColor("#66000000".toColorInt())
+              val dp16 = dpToPx(16)
+              setPadding(0, dp16, 0, dp16) // Remove horizontal padding
+              gravity = Gravity.CENTER_VERTICAL // Change to center vertical
+            }
 
     val cancelBtn =
-      AppCompatButton(this).apply {
-        text = "Cancel"
-        layoutParams = LinearLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).withMargin()
-        setOnClickListener {
-          setResult(RESULT_CANCELED)
-          finish()
-        }
-      }
+            AppCompatButton(this).apply {
+              text = "CANCEL"
+              setTextColor(Color.WHITE)
+              setBackgroundColor(Color.TRANSPARENT) // Transparent background
+              layoutParams =
+                      LinearLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).apply {
+                        // No weight to prevent stretching
+                        setMargins(dpToPx(16), 0, 0, 0) // Left margin only
+                      }
+              setOnClickListener {
+                setResult(RESULT_CANCELED)
+                finish()
+              }
+            }
     bar.addView(cancelBtn)
 
+    // Spacer to push reset to center
+    val leftSpacer = View(this).apply { layoutParams = LinearLayout.LayoutParams(0, 0, 1f) }
+    bar.addView(leftSpacer)
+
     val resetBtn =
-      AppCompatButton(this).apply {
-        text = "Reset"
-        layoutParams = LinearLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).withMargin()
-        setOnClickListener {
-          if (options?.rotationEnabled != false && prevRotation != 0) {
-            cropView.rotateImage(-1 * prevRotation)
-            prevRotation = 0
-          }
-          cropView.resetCropRect()
-        }
-      }
+            AppCompatImageButton(this).apply {
+              // Use the reset icon
+              setImageResource(R.drawable.ic_reset)
+
+              // Set content description for accessibility
+              contentDescription = "Reset"
+
+              // Make the icon white
+              setColorFilter(Color.WHITE)
+
+              // Set a transparent background
+              setBackgroundColor(Color.TRANSPARENT)
+
+              // Set the layout parameters with proper sizing
+              val buttonSize = dpToPx(48)
+              layoutParams = LinearLayout.LayoutParams(buttonSize, buttonSize)
+
+              // Set padding inside the button
+              val padding = dpToPx(12)
+              setPadding(padding, padding, padding, padding)
+
+              // Set the click listener
+              setOnClickListener {
+                if (options?.rotationEnabled != false && prevRotation != 0) {
+                  cropView.rotateImage(-1 * prevRotation)
+                  prevRotation = 0
+                }
+                cropView.resetCropRect()
+              }
+            }
+
     bar.addView(resetBtn)
 
     if (options.rotationEnabled != false) {
-    val rotateBtn =
-      AppCompatButton(this).apply {
-        text = "Rotate"
-        layoutParams = LinearLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).withMargin()
-        setOnClickListener {
-          cropView.rotateImage(90)
-          prevRotation = (prevRotation + 90) % 360
-        }
-      }
+      val rotateBtn =
+              AppCompatImageButton(this).apply {
+                // Use the Material Design icon for rotation
+                setImageResource(R.drawable.ic_rotate)
+
+                // Set content description for accessibility
+                contentDescription = "Rotate"
+
+                // Make the icon white
+                setColorFilter(Color.WHITE)
+
+                // Set a transparent background
+                setBackgroundColor(Color.TRANSPARENT)
+
+                // Set the layout parameters with proper sizing
+                val buttonSize = dpToPx(48)
+                layoutParams = LinearLayout.LayoutParams(buttonSize, buttonSize)
+
+                // Set padding inside the button
+                val padding = dpToPx(12)
+                setPadding(padding, padding, padding, padding)
+
+                // Set the click listener
+                setOnClickListener {
+                  cropView.rotateImage(90)
+                  prevRotation = (prevRotation + 90) % 360
+                }
+              }
       bar.addView(rotateBtn)
     }
 
+    // Spacer to push done to right
+    val rightSpacer = View(this).apply { layoutParams = LinearLayout.LayoutParams(0, 0, 1f) }
+    bar.addView(rightSpacer)
+
+    // Done button (right-aligned)
     val doneBtn =
-      AppCompatButton(this).apply {
-        text = "Done"
-        layoutParams = LinearLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).withMargin()
-        setOnClickListener { onDone() }
-      }
+            AppCompatButton(this).apply {
+              text = "DONE"
+              setTextColor(Color.YELLOW)
+              setBackgroundColor(Color.TRANSPARENT) // Transparent background
+              layoutParams =
+                      LinearLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).apply {
+                        // No weight to prevent stretching
+                        setMargins(0, 0, dpToPx(16), 0) // Right margin only
+                      }
+              setOnClickListener { onDone() }
+            }
     bar.addView(doneBtn)
 
     root.addView(
-      bar,
-      FrameLayout.LayoutParams(
-        MATCH_PARENT,
-        WRAP_CONTENT,
-        Gravity.BOTTOM,
-      ),
+            bar,
+            FrameLayout.LayoutParams(
+                    MATCH_PARENT,
+                    WRAP_CONTENT,
+                    Gravity.BOTTOM,
+            ),
     )
 
     setContentView(root)
@@ -202,15 +254,14 @@ class CropperActivity : AppCompatActivity() {
         it.systemBarsBehavior = android.view.WindowInsetsController.BEHAVIOR_DEFAULT
       }
     } else {
-      @Suppress("DEPRECATION")
-      window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+      @Suppress("DEPRECATION") window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
     }
   }
 
   fun onDone() {
     var bmap = cropView?.getCroppedImage() ?: return
 
-    if (options?.rotationEnabled != false &&prevRotation != 0) {
+    if (options?.rotationEnabled != false && prevRotation != 0) {
       bmap = bmap.rotate(prevRotation.toFloat())
     }
 
@@ -222,45 +273,44 @@ class CropperActivity : AppCompatActivity() {
       val quality = (intent.getDoubleExtra("compressImageQuality", 1.0) * 100).toInt()
       Log.d("ExpoCropTool", "quality was $quality")
       bmap.compress(
-        when (format) {
-          "png" -> android.graphics.Bitmap.CompressFormat.PNG
-          "jpeg" -> android.graphics.Bitmap.CompressFormat.JPEG
-          else -> {
-            setResult(CropperError.Arguments.getResultCode(), null)
-            finish()
-            return
-          }
-        },
-        quality,
-        out,
+              when (format) {
+                "png" -> android.graphics.Bitmap.CompressFormat.PNG
+                "jpeg" -> android.graphics.Bitmap.CompressFormat.JPEG
+                else -> {
+                  setResult(CropperError.Arguments.getResultCode(), null)
+                  finish()
+                  return
+                }
+              },
+              quality,
+              out,
       )
-    } ?: run {
-      setResult(CropperError.WriteData.getResultCode(), null)
-      finish()
-      return
     }
+            ?: run {
+              setResult(CropperError.WriteData.getResultCode(), null)
+              finish()
+              return
+            }
 
     out.close()
 
     val result =
-      OpenCropperResult()
-        .apply {
-          path = uri.toString()
-          mimeType =
-            when (format) {
-              "png" -> "image/png"
-              "jpeg" -> "image/jpeg"
-              else -> null
-            }
-          size = bmap.byteCount
-          width = bmap.width
-          height = bmap.height
-        }.toBundle()
+            OpenCropperResult()
+                    .apply {
+                      path = uri.toString()
+                      mimeType =
+                              when (format) {
+                                "png" -> "image/png"
+                                "jpeg" -> "image/jpeg"
+                                else -> null
+                              }
+                      size = bmap.byteCount
+                      width = bmap.width
+                      height = bmap.height
+                    }
+                    .toBundle()
 
-    val resIntent =
-      Intent().apply {
-        putExtras(result)
-      }
+    val resIntent = Intent().apply { putExtras(result) }
 
     setResult(RESULT_OK, resIntent)
     finish()

--- a/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperActivity.kt
+++ b/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperActivity.kt
@@ -136,6 +136,7 @@ class CropperActivity : AppCompatActivity() {
     val cancelBtn =
       AppCompatButton(this).apply {
         text = "Cancel"
+        layoutParams = LinearLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).withMargin()
         setOnClickListener {
           setResult(RESULT_CANCELED)
           finish()
@@ -148,13 +149,16 @@ class CropperActivity : AppCompatActivity() {
         text = "Reset"
         layoutParams = LinearLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).withMargin()
         setOnClickListener {
-          cropView.rotateImage(-1 * prevRotation)
+          if (options?.rotationEnabled != false && prevRotation != 0) {
+            cropView.rotateImage(-1 * prevRotation)
+            prevRotation = 0
+          }
           cropView.resetCropRect()
-          prevRotation = 0
         }
       }
     bar.addView(resetBtn)
 
+    if (options.rotationEnabled != false) {
     val rotateBtn =
       AppCompatButton(this).apply {
         text = "Rotate"
@@ -164,7 +168,8 @@ class CropperActivity : AppCompatActivity() {
           prevRotation = (prevRotation + 90) % 360
         }
       }
-    bar.addView(rotateBtn)
+      bar.addView(rotateBtn)
+    }
 
     val doneBtn =
       AppCompatButton(this).apply {
@@ -205,7 +210,7 @@ class CropperActivity : AppCompatActivity() {
   fun onDone() {
     var bmap = cropView?.getCroppedImage() ?: return
 
-    if (prevRotation != 0) {
+    if (options?.rotationEnabled != false &&prevRotation != 0) {
       bmap = bmap.rotate(prevRotation.toFloat())
     }
 

--- a/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperTypes.kt
+++ b/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperTypes.kt
@@ -30,7 +30,7 @@ class OpenCropperOptions(
         aspectRatio = bundle.getDouble("aspectRatio"),
         format = bundle.getString("format"),
         compressImageQuality = bundle.getDouble("compressImageQuality"),
-        rotationEnabled = bundle.getBoolean("rotationEnabled", true)
+        rotationEnabled = bundle.getBoolean("rotationEnabled", true),
       )
   }
 }

--- a/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperTypes.kt
+++ b/android/src/main/java/xyz/blueskyweb/expoimagecroptool/CropperTypes.kt
@@ -10,6 +10,7 @@ class OpenCropperOptions(
   @Field var aspectRatio: Double? = null,
   @Field var format: String? = null,
   @Field var compressImageQuality: Double? = null,
+  @Field var rotationEnabled: Boolean? = true,
 ) : Record {
   fun toBundle(): Bundle =
     Bundle().apply {
@@ -18,6 +19,7 @@ class OpenCropperOptions(
       putDouble("aspectRatio", aspectRatio ?: 0.0)
       putString("format", format)
       putDouble("compressImageQuality", compressImageQuality ?: 1.0)
+      putBoolean("rotationEnabled", rotationEnabled ?: true)
     }
 
   companion object {
@@ -28,6 +30,7 @@ class OpenCropperOptions(
         aspectRatio = bundle.getDouble("aspectRatio"),
         format = bundle.getString("format"),
         compressImageQuality = bundle.getDouble("compressImageQuality"),
+        rotationEnabled = bundle.getBoolean("rotationEnabled", true)
       )
   }
 }

--- a/android/src/main/res/drawable/ic_reset.xml
+++ b/android/src/main/res/drawable/ic_reset.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>

--- a/android/src/main/res/drawable/ic_rotate.xml
+++ b/android/src/main/res/drawable/ic_rotate.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M7.11,8.53L5.7,7.11C4.8,8.27 4.24,9.61 4.07,11h2.02c0.14,-0.87 0.49,-1.72 1.02,-2.47zM6.09,13L4.07,13c0.17,1.39 0.72,2.73 1.62,3.89l1.41,-1.42c-0.52,-0.75 -0.87,-1.59 -1.01,-2.47zM7.1,18.32c1.16,0.9 2.51,1.44 3.9,1.61L11,17.9c-0.87,-0.15 -1.71,-0.49 -2.46,-1.03L7.1,18.32zM13,4.07L13,1L8.45,5.55 13,10L13,6.09c2.84,0.48 5,2.94 5,5.91s-2.16,5.43 -5,5.91v2.02c3.95,-0.49 7,-3.85 7,-7.93s-3.05,-7.44 -7,-7.93z"/>
+</vector>

--- a/example/android/app/src/main/java/xyz/blueskyweb/expoimagecroptool/example/MainActivity.kt
+++ b/example/android/app/src/main/java/xyz/blueskyweb/expoimagecroptool/example/MainActivity.kt
@@ -2,12 +2,10 @@ package xyz.blueskyweb.expoimagecroptool.example
 
 import android.os.Build
 import android.os.Bundle
-
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
-
 import expo.modules.ReactActivityDelegateWrapper
 
 class MainActivity : ReactActivity() {
@@ -15,7 +13,7 @@ class MainActivity : ReactActivity() {
     // Set the theme to AppTheme BEFORE onCreate to support
     // coloring the background, status bar, and navigation bar.
     // This is required for expo-splash-screen.
-    setTheme(R.style.AppTheme);
+    setTheme(R.style.AppTheme)
     super.onCreate(null)
   }
 
@@ -29,33 +27,33 @@ class MainActivity : ReactActivity() {
    * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]
    * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
    */
-  override fun createReactActivityDelegate(): ReactActivityDelegate {
-    return ReactActivityDelegateWrapper(
-          this,
-          BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
-          object : DefaultReactActivityDelegate(
-              this,
-              mainComponentName,
-              fabricEnabled
-          ){})
-  }
+  override fun createReactActivityDelegate(): ReactActivityDelegate =
+    ReactActivityDelegateWrapper(
+      this,
+      BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
+      object : DefaultReactActivityDelegate(
+        this,
+        mainComponentName,
+        fabricEnabled,
+      ) {},
+    )
 
   /**
-    * Align the back button behavior with Android S
-    * where moving root activities to background instead of finishing activities.
-    * @see <a href="https://developer.android.com/reference/android/app/Activity#onBackPressed()">onBackPressed</a>
-    */
+   * Align the back button behavior with Android S
+   * where moving root activities to background instead of finishing activities.
+   * @see <a href="https://developer.android.com/reference/android/app/Activity#onBackPressed()">onBackPressed</a>
+   */
   override fun invokeDefaultOnBackPressed() {
-      if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
-          if (!moveTaskToBack(false)) {
-              // For non-root activities, use the default implementation to finish them.
-              super.invokeDefaultOnBackPressed()
-          }
-          return
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
+      if (!moveTaskToBack(false)) {
+        // For non-root activities, use the default implementation to finish them.
+        super.invokeDefaultOnBackPressed()
       }
+      return
+    }
 
-      // Use the default back button implementation on Android S
-      // because it's doing more than [Activity.moveTaskToBack] in fact.
-      super.invokeDefaultOnBackPressed()
+    // Use the default back button implementation on Android S
+    // because it's doing more than [Activity.moveTaskToBack] in fact.
+    super.invokeDefaultOnBackPressed()
   }
 }

--- a/example/android/app/src/main/java/xyz/blueskyweb/expoimagecroptool/example/MainApplication.kt
+++ b/example/android/app/src/main/java/xyz/blueskyweb/expoimagecroptool/example/MainApplication.kt
@@ -2,40 +2,40 @@ package xyz.blueskyweb.expoimagecroptool.example
 
 import android.app.Application
 import android.content.res.Configuration
-
 import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
+import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
-import com.facebook.react.ReactHost
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
 import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
-
 import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ReactNativeHostWrapper
 
-class MainApplication : Application(), ReactApplication {
+class MainApplication :
+  Application(),
+  ReactApplication {
+  override val reactNativeHost: ReactNativeHost =
+    ReactNativeHostWrapper(
+      this,
+      object : DefaultReactNativeHost(this) {
+        override fun getPackages(): List<ReactPackage> {
+          val packages = PackageList(this).packages
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // packages.add(new MyReactNativePackage());
+          return packages
+        }
 
-  override val reactNativeHost: ReactNativeHost = ReactNativeHostWrapper(
-        this,
-        object : DefaultReactNativeHost(this) {
-          override fun getPackages(): List<ReactPackage> {
-            val packages = PackageList(this).packages
-            // Packages that cannot be autolinked yet can be added manually here, for example:
-            // packages.add(new MyReactNativePackage());
-            return packages
-          }
+        override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"
 
-          override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"
+        override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
 
-          override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
-
-          override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
-          override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
-      }
-  )
+        override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+        override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+      },
+    )
 
   override val reactHost: ReactHost
     get() = ReactNativeHostWrapper.createReactHost(applicationContext, reactNativeHost)

--- a/ios/Cropper.swift
+++ b/ios/Cropper.swift
@@ -61,6 +61,11 @@ class Cropper: NSObject, CropViewControllerDelegate {
 
     var viewConfig = Mantis.CropViewConfig()
 
+    if options.rotationControlEnabled == false {
+      // Disable rotation control view if rotationControlEnabled is false
+      viewConfig.showAttachedRotationControlView = false
+    }
+
     // Disable rotation control view if rotationEnabled is false
     if options.rotationEnabled == false {
       // Create a toolbar config with rotation buttons removed

--- a/ios/Cropper.swift
+++ b/ios/Cropper.swift
@@ -63,8 +63,6 @@ class Cropper: NSObject, CropViewControllerDelegate {
 
     // Disable rotation control view if rotationEnabled is false
     if options.rotationEnabled == false {
-      viewConfig.showAttachedRotationControlView = false
-
       // Create a toolbar config with rotation buttons removed
       var toolbarConfig = Mantis.CropToolbarConfig()
 

--- a/ios/Cropper.swift
+++ b/ios/Cropper.swift
@@ -35,7 +35,10 @@ class Cropper: NSObject, CropViewControllerDelegate {
   var onCrop: ((OpenCropperResult) -> Void)!
   var onError: ((Error) -> Void)!
 
-  init(options: OpenCropperOptions, onCrop: @escaping(OpenCropperResult) -> Void, onError: @escaping(Error) -> Void) throws {
+  init(
+    options: OpenCropperOptions, onCrop: @escaping (OpenCropperResult) -> Void,
+    onError: @escaping (Error) -> Void
+  ) throws {
     super.init()
 
     guard let image = UIImage(contentsOfFile: options.imageUri.deletingPrefix("file://")) else {
@@ -57,6 +60,26 @@ class Cropper: NSObject, CropViewControllerDelegate {
     }
 
     var viewConfig = Mantis.CropViewConfig()
+
+    // Disable rotation control view if rotationEnabled is false
+    if options.rotationEnabled == false {
+      viewConfig.showAttachedRotationControlView = false
+
+      // Create a toolbar config with rotation buttons removed
+      var toolbarConfig = Mantis.CropToolbarConfig()
+
+      // Get the default options and remove rotation options
+      var buttonOptions = toolbarConfig.toolbarButtonOptions
+      buttonOptions.remove(.clockwiseRotate)
+      buttonOptions.remove(.counterclockwiseRotate)
+
+      // Set the modified options back
+      toolbarConfig.toolbarButtonOptions = buttonOptions
+
+      // Assign the toolbar config to the main config
+      config.cropToolbarConfig = toolbarConfig
+    }
+
     if options.shape == "circle" {
       config.ratioOptions = []
       viewConfig.cropShapeType = .circle(maskOnly: true)
@@ -70,7 +93,10 @@ class Cropper: NSObject, CropViewControllerDelegate {
     self.cropVc = cropVc
   }
 
-  public func cropViewControllerDidCrop(_ cropViewController: Mantis.CropViewController, cropped: UIImage, transformation: Mantis.Transformation, cropInfo: Mantis.CropInfo) {
+  public func cropViewControllerDidCrop(
+    _ cropViewController: Mantis.CropViewController, cropped: UIImage,
+    transformation: Mantis.Transformation, cropInfo: Mantis.CropInfo
+  ) {
     var data: Data?
 
     if self.options.format == "jpeg" {
@@ -109,7 +135,9 @@ class Cropper: NSObject, CropViewControllerDelegate {
     cropViewController.dismiss(animated: true)
   }
 
-  public func cropViewControllerDidCancel(_ cropViewController: Mantis.CropViewController, original: UIImage) {
+  public func cropViewControllerDidCancel(
+    _ cropViewController: Mantis.CropViewController, original: UIImage
+  ) {
     cropViewController.dismiss(animated: true)
     self.onError(CropperError.cancelled)
   }
@@ -130,7 +158,8 @@ class Cropper: NSObject, CropViewControllerDelegate {
 
   private static func getTempUrl(ext: String) -> URL? {
     let dir = FileManager().temporaryDirectory
-    return URL(string: "\(dir.absoluteString)\(ProcessInfo.processInfo.globallyUniqueString).\(ext)")!
+    return URL(
+      string: "\(dir.absoluteString)\(ProcessInfo.processInfo.globallyUniqueString).\(ext)")!
   }
 }
 

--- a/ios/CropperTypes.swift
+++ b/ios/CropperTypes.swift
@@ -15,6 +15,9 @@ struct OpenCropperOptions: Record {
 
   @Field
   var compressImageQuality: Float = 1.0
+
+  @Field
+  var rotationEnabled: Bool = true
 }
 
 struct OpenCropperResult: Record {

--- a/ios/CropperTypes.swift
+++ b/ios/CropperTypes.swift
@@ -18,6 +18,9 @@ struct OpenCropperOptions: Record {
 
   @Field
   var rotationEnabled: Bool = true
+
+  @Field
+  var rotationControlEnabled: Bool = true
 }
 
 struct OpenCropperResult: Record {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-image-crop-tool",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "An image cropper for Expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/ExpoImageCropTool.types.ts
+++ b/src/ExpoImageCropTool.types.ts
@@ -5,6 +5,7 @@ export interface OpenCropperOptions {
   format?: "jpeg" | "png";
   compressImageQuality?: number;
   rotationEnabled?: boolean;
+  rotationControlEnabled?: boolean;
 }
 
 export interface OpenCropperResult {

--- a/src/ExpoImageCropTool.types.ts
+++ b/src/ExpoImageCropTool.types.ts
@@ -4,6 +4,7 @@ export interface OpenCropperOptions {
   aspectRatio?: number;
   format?: "jpeg" | "png";
   compressImageQuality?: number;
+  rotationEnabled?: boolean;
 }
 
 export interface OpenCropperResult {


### PR DESCRIPTION
Instead of forcing the rotate button, set it as a OpenCropperOption called `rotationEnabled`. This uses Mantis to remove counterClockwise and clockwise rotation buttons from the Toolbar on both platforms. I've tested this on iOS and Android and it works great. For my case, I don't want the users to be able to rotate the image.

