### PR TITLE
fix: mime type should be mimeType

### DIFF
--- a/src/ExpoImageCropTool.types.ts
+++ b/src/ExpoImageCropTool.types.ts
@@ -10,7 +10,7 @@ export interface OpenCropperOptions {
 
 export interface OpenCropperResult {
   path: string;
-  mime: string;
+  mimeType: string;
   size: number;
   width: number;
   height: number;


### PR DESCRIPTION
There seemed to be misaligned types between the native and js side on `mime`, proper one should be `mimeType`.